### PR TITLE
Delete unused EC2 instances response

### DIFF
--- a/identify_stale_snapshots.py
+++ b/identify_stale_snapshots.py
@@ -6,14 +6,6 @@ def lambda_handler(event, context):
     # Get all EBS snapshots
     response = ec2.describe_snapshots(OwnerIds=['self'])
 
-    # Get all active EC2 instance IDs
-    instances_response = ec2.describe_instances(Filters=[{'Name': 'instance-state-name', 'Values': ['running']}])
-    active_instance_ids = set()
-
-    for reservation in instances_response['Reservations']:
-        for instance in reservation['Instances']:
-            active_instance_ids.add(instance['InstanceId'])
-
     # Iterate through each snapshot and delete if it's not attached to any volume or the volume is not attached to a running instance
     for snapshot in response['Snapshots']:
         snapshot_id = snapshot['SnapshotId']


### PR DESCRIPTION
`instances_response` and `active_instance_ids` seem not needed.